### PR TITLE
Add logout endpoint option

### DIFF
--- a/modules/auth/store.js
+++ b/modules/auth/store.js
@@ -5,7 +5,7 @@
 
 import Cookie from 'cookie'
 import Cookies from 'js-cookie'
-import {setToken, $get, $post} from './axios' // Axios is a peer plugin dependency
+import {setToken, $get, $post, $delete} from './axios' // Axios is a peer plugin dependency
 
 const inBrowser = typeof window !== 'undefined'
 const SSR = global.__VUE_SSR_CONTEXT__
@@ -105,12 +105,15 @@ function AuthStore (opts) {
       })
     },
 
-    logout (ctx) {
+    logout (ctx, {endpoint = '/auth/logout', appendToken = false}) {
             // Unload user profile
       ctx.commit('setUser', null)
 
+            // Create logout endpoint
+      const endpoint = endpoint + appendToken ? `/${ctx.state.token}` : ''
+
             // Server side logout
-      return $get('/auth/logout').then(() => {
+      return $delete(endpoint).then(() => {
                 // Unset token
         ctx.commit('setToken', null)
       }).catch(() => {

--- a/modules/auth/store.js
+++ b/modules/auth/store.js
@@ -109,8 +109,8 @@ function AuthStore (opts) {
             // Unload user profile
       ctx.commit('setUser', null)
 
-            // Create logout endpoint
-      const endpoint = endpoint + appendToken ? `/${ctx.state.token}` : ''
+            // Append token
+      if (appendToken) endpoint = endpoint + `/${ctx.state.token}`
 
             // Server side logout
       return $delete(endpoint).then(() => {


### PR DESCRIPTION
Added logout endpoint option!

This code is example for case of [Laravel passport](https://laravel.com/docs/5.4/passport) (Password Grant Tokens)

```php
// Endpoint is /oauth/tokens/eyJ0eXAiOiJKV1Qi.......
this.logout({
  endpoint: 'oauth/tokens',
  appendToken: true
})
```