### PR TITLE
export default axios instance

### DIFF
--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -113,3 +113,5 @@ Vue.use(VueAxios)
 export const setToken = function (token) {
   axios.defaults.headers.common.Authorization = token ? `Bearer ${token}` : null
 }
+
+export default axios


### PR DESCRIPTION
export default axios instance so that user can do some things with it. eg https://github.com/nuxt/express/blob/master/protected-ssr-api.md#create-middlewaressr-cookiejs

```js
import axios from '../.nuxt-modules/modules/nuxt_axios_plugin'

export default function({isServer, req}) {
  if (isServer) {
    axios.defaults.headers.common.cookie = req.headers.cookie
  }
}
```